### PR TITLE
Update main.ring - When using (ringpm run) - Open the documentation

### DIFF
--- a/main.ring
+++ b/main.ring
@@ -5,3 +5,10 @@ load "lib.ring"
 func main
 
 	? "Loaded Jetpack!"
+
+	if isWindows()
+		cDir = currentdir()
+		chdir("documents/build/html_ja-jp")
+		system("index.html")
+		chdir(cDir)
+	ok


### PR DESCRIPTION
Support opening the documentation directly using the Package Manager (ringpm)

As we have in (ringpm run ringhelphtml)

